### PR TITLE
feat(exam): start exam session via API

### DIFF
--- a/v2/src/apis/gasApi.js
+++ b/v2/src/apis/gasApi.js
@@ -35,4 +35,10 @@ export const gasApi = {
             };
         }
     },
+
+    async startExam(examId, userId) {
+        const res = await fetch(`${VITE_GAS_SPI_BASE_URL}?action=startExam&user_id=${userId}&exam_id=${examId}`);
+        if (!res.ok) throw new Error("試験開始失敗");
+        return res.json();
+    }
 };

--- a/v2/src/stores/exam.js
+++ b/v2/src/stores/exam.js
@@ -1,5 +1,5 @@
 import { defineStore } from "pinia";
-import { ref } from "vue";
+import { ref, useId } from "vue";
 import { api } from "@/apis/apiFactory";
 import { createCachedStore } from "./factories/useCachedStoreFactory";
 
@@ -14,9 +14,9 @@ export const useExamStore = defineStore("exam", () => {
 	const localTimeLeft = ref(30);
 	const currentIndex = ref(0);
 
-	const startExam = async (examId) => {
+	const startExam = async (examId, userId) => {
 		try {
-			const session = await api.startExam(examId);
+			const session = await api.startExam(examId, userId);
 			return session.session_id;
 		} catch (error) {
 			store.error.value = error.message || "試験の開始に失敗しました";

--- a/v2/src/views/exam/ExamList.vue
+++ b/v2/src/views/exam/ExamList.vue
@@ -53,19 +53,22 @@
 	import { onMounted } from "vue";
 	import { useRouter } from "vue-router";
 	import { useExamStore } from "@/stores/exam";
+	import { useSessionStore } from "@/stores/session";
 	import Card from "@/components/ui/Card.vue";
 
 	const router = useRouter();
 	const examStore = useExamStore();
+	const sessionStore = useSessionStore();
 
 	onMounted(() => {
 		examStore.load();
 	});
 
 	async function startExam(examId) {
-		const session_id = await examStore.startExam(examId);
+		const session_id = sessionStore.sessionId.value;
+		const exam_session_id = await examStore.startExam(examId);
 		if (!session_id) return;
-		router.push(`/spi/${session_id}`);
+		router.push(`/spi/${exam_session_id}`);
 	}
 
 	const goToReview = (examId) => {


### PR DESCRIPTION
- modified gasApi.js to support starting exam session
- updated exam store for session handling
- adjusted ExamList.vue to integrate new session start flow